### PR TITLE
Add support for esp32

### DIFF
--- a/main/cmd_can.c
+++ b/main/cmd_can.c
@@ -185,6 +185,7 @@ static int canup(int argc, char **argv) {
             break;
     }
     switch (canup_args.speed->ival[0]) {
+        #if CONFIG_IDF_TARGET_ESP32C3
         case 1000:
             t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_1KBITS();
             break;
@@ -203,6 +204,7 @@ static int canup(int argc, char **argv) {
         case 20000:
             t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_20KBITS();
             break;
+        #endif
         case 25000:
             t_config = (twai_timing_config_t) TWAI_TIMING_CONFIG_25KBITS();
             break;


### PR DESCRIPTION
I've added support for the project to be compiled and used on a 'bare' ESP32.
The project now compiles for both 'ESP32' and 'ESP32-C3'. 